### PR TITLE
add request timeout

### DIFF
--- a/bin/user/wll.py
+++ b/bin/user/wll.py
@@ -124,7 +124,7 @@ class WLL(weewx.drivers.AbstractDevice):
 
                 try:
 
-                    response = requests.get(self.service_url)
+                    response = requests.get(self.service_url, timeout=self.poll_interval)
 
                 except Exception as exception:
 


### PR DESCRIPTION
It is good practice to specify some timeout. My weewx froze on recvfrom() syscall and I think it was due to this get request. Although I am not 100%, adding timeout shouldn't hurt anyone...